### PR TITLE
chore: align runtime config with A2A environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,14 @@ uv tool upgrade compass-a2a
 Run (complete example)
 
 ```bash
- A2A_HOST=127.0.0.1 \
+ A2A_HOST=0.0.0.0 \
  A2A_PORT=8000 \
  A2A_PUBLIC_URL=http://127.0.0.1:8000 \
+ A2A_COMPASS_API_BASE_URL=http://127.0.0.1:8000/api/v1 \
 compass-a2a
 ```
+
+`A2A_COMPASS_API_BASE_URL` is required and should point to the upstream Compass API service used for identity, skill dispatch, and token exchange.
 
 Public endpoints:
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ compass-a2a
 
 `A2A_COMPASS_API_BASE_URL` is required and should point to the upstream Compass API service used for identity, skill dispatch, and token exchange.
 
+Required environment variables:
+
+- `A2A_HOST`
+- `A2A_PORT`
+- `A2A_PUBLIC_URL`
+- `A2A_COMPASS_API_BASE_URL`
+
 Public endpoints:
 
 - `GET /.well-known/agent-card.json`

--- a/README.md
+++ b/README.md
@@ -20,26 +20,25 @@ This repository is initialized with:
 
 ## Quick Start
 
-Install and run from a release with `uv tool`:
+Install
 
 ```bash
 uv tool install compass-a2a
-compass-a2a
 ```
 
-Use this complete command to run:
-
-```bash
-A2A_HOST=127.0.0.1 \
-A2A_PORT=8000 \
-A2A_PUBLIC_URL=http://127.0.0.1:8000 \
-compass-a2a
-```
-
-`uv tool upgrade` can be used to keep the installed tool up to date:
+Upgrade
 
 ```bash
 uv tool upgrade compass-a2a
+```
+
+Run (complete example)
+
+```bash
+ A2A_HOST=127.0.0.1 \
+ A2A_PORT=8000 \
+ A2A_PUBLIC_URL=http://127.0.0.1:8000 \
+compass-a2a
 ```
 
 Public endpoints:

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ uv tool upgrade compass-a2a
 Run (complete example)
 
 ```bash
- A2A_HOST=0.0.0.0 \
- A2A_PORT=8000 \
- A2A_PUBLIC_URL=http://127.0.0.1:8000 \
- A2A_COMPASS_API_BASE_URL=http://127.0.0.1:8000/api/v1 \
+A2A_HOST=0.0.0.0 \
+A2A_PORT=8000 \
+A2A_PUBLIC_URL=https://your-domain.example.com/compass-a2a \
+A2A_COMPASS_API_BASE_URL=https://your-domain.example.com/api/v1 \
 compass-a2a
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,14 +20,38 @@ This repository is initialized with:
 
 ## Quick Start
 
+Install and run from a release with `uv tool`:
+
 ```bash
-uv sync --extra dev
-cp .env.example .env
-uv run pre-commit install
-uv run compass-a2a
+uv tool install compass-a2a
+compass-a2a
 ```
 
-By default the server listens on `http://127.0.0.1:8000`.
+By default, the service listens on `http://127.0.0.1:8000`, and the Agent Card URL
+is generated from the startup `host:port`.
+
+For a complete launch example:
+
+```bash
+A2A_HOST=127.0.0.1 \
+A2A_PORT=8000 \
+compass-a2a
+```
+
+If the service is exposed through a public endpoint, set `A2A_PUBLIC_URL` explicitly:
+
+```bash
+A2A_HOST=0.0.0.0 \
+A2A_PORT=8000 \
+A2A_PUBLIC_URL=http://public.example.com/compass-a2a \
+compass-a2a
+```
+
+`uv tool upgrade` can be used to keep the installed tool up to date:
+
+```bash
+uv tool upgrade compass-a2a
+```
 
 Public endpoints:
 
@@ -63,9 +87,9 @@ refresh skew, and cache size limits so expired or cold entries are recycled.
 
 Optional cache tuning env vars:
 
-- `COMPASS_A2A_TOKEN_CACHE_TTL_SECONDS`
-- `COMPASS_A2A_TOKEN_CACHE_REFRESH_SKEW_SECONDS`
-- `COMPASS_A2A_TOKEN_CACHE_MAX_ENTRIES`
+- `A2A_TOKEN_CACHE_TTL_SECONDS`
+- `A2A_TOKEN_CACHE_REFRESH_SKEW_SECONDS`
+- `A2A_TOKEN_CACHE_MAX_ENTRIES`
 
 ## Capability Model
 

--- a/README.md
+++ b/README.md
@@ -27,23 +27,12 @@ uv tool install compass-a2a
 compass-a2a
 ```
 
-By default, the service listens on `http://127.0.0.1:8000`, and the Agent Card URL
-is generated from the startup `host:port`.
-
-For a complete launch example:
+Use this complete command to run:
 
 ```bash
 A2A_HOST=127.0.0.1 \
 A2A_PORT=8000 \
-compass-a2a
-```
-
-If the service is exposed through a public endpoint, set `A2A_PUBLIC_URL` explicitly:
-
-```bash
-A2A_HOST=0.0.0.0 \
-A2A_PORT=8000 \
-A2A_PUBLIC_URL=http://public.example.com/compass-a2a \
+A2A_PUBLIC_URL=http://127.0.0.1:8000 \
 compass-a2a
 ```
 

--- a/scripts/smoke_test_built_cli.sh
+++ b/scripts/smoke_test_built_cli.sh
@@ -67,9 +67,9 @@ with socket.socket() as sock:
 PY
 )"
 
-COMPASS_A2A_PORT="${port}" \
-COMPASS_A2A_HOST="127.0.0.1" \
-COMPASS_A2A_COMPASS_API_BASE_URL="http://127.0.0.1:${port}/api/v1" \
+A2A_PORT="${port}" \
+A2A_HOST="127.0.0.1" \
+A2A_COMPASS_API_BASE_URL="http://127.0.0.1:${port}/api/v1" \
 "${tool_bin_dir}/compass-a2a" >"${server_log}" 2>&1 &
 server_pid="$!"
 

--- a/src/compass_a2a/agent_card.py
+++ b/src/compass_a2a/agent_card.py
@@ -14,7 +14,7 @@ from .read_skills import build_read_skill_catalog
 
 
 def build_agent_card(settings: Settings) -> AgentCard:
-    base_url = settings.public_url.rstrip("/")
+    base_url = (settings.public_url or f"http://{settings.host}:{settings.port}").rstrip("/")
     return AgentCard(
         name="compass-a2a",
         description=(

--- a/src/compass_a2a/cli.py
+++ b/src/compass_a2a/cli.py
@@ -1,32 +1,18 @@
-from __future__ import annotations
-
-import argparse
-
 import uvicorn
 
 from .config import Settings
 
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="compass-a2a",
-        description="Run the compass-a2a adapter service.",
-    )
-    parser.add_argument("--host", help="Host override.")
-    parser.add_argument("--port", type=int, help="Port override.")
-    parser.add_argument("--reload", action="store_true", help="Enable autoreload.")
-    return parser
-
-
 def main() -> int:
-    args = build_parser().parse_args()
     settings = Settings()
+    if settings.public_url is None:
+        settings.public_url = f"http://{settings.host}:{settings.port}"
+
     uvicorn.run(
         "compass_a2a.app:build_app",
         factory=True,
-        host=args.host or settings.host,
-        port=args.port or settings.port,
-        reload=args.reload,
+        host=settings.host,
+        port=settings.port,
         log_level=settings.log_level.lower(),
     )
     return 0

--- a/src/compass_a2a/config.py
+++ b/src/compass_a2a/config.py
@@ -7,7 +7,7 @@ class Settings(BaseSettings):
     app_name: str = "compass-a2a"
     host: str = "127.0.0.1"
     port: int = 8000
-    public_url: str = "http://127.0.0.1:8000"
+    public_url: str | None = None
     log_level: str = "INFO"
 
     compass_api_base_url: str = "http://127.0.0.1:8000/api/v1"
@@ -18,7 +18,6 @@ class Settings(BaseSettings):
     token_cache_max_entries: int = 256
 
     model_config = SettingsConfigDict(
-        env_file=".env",
-        env_prefix="COMPASS_A2A_",
+        env_prefix="A2A_",
         extra="ignore",
     )


### PR DESCRIPTION
## 变更说明

### 运行与配置
- 统一运行参数入口为环境变量 `A2A_` 前缀，移除 CLI 变体参数。
- `Settings` 的环境变量前缀由 `COMPASS_A2A_` 调整为 `A2A_`。
- 默认公开 URL 在未设置时按当前启动 `host:port` 动态组装。

### Agent Card
- 调整 Agent Card URL 解析逻辑：优先使用显式 `public_url`，否则按 `host:port` 动态计算，避免固定 `http://127.0.0.1:8000`。

### 文档与脚本
- 更新 README 快速启动示例，改为纯环境变量启动示例。
- 更新可选缓存变量为 `A2A_` 前缀。
- 调整 `scripts/smoke_test_built_cli.sh` 的环境变量为 `A2A_` 前缀。

## 变更覆盖/审查
- 该改动实现了对配置风格一致性的要求，并与单一入口策略一致。
- 兼容性：对外部调用会影响原有 `COMPASS_A2A_` 命名环境变量与旧 CLI 参数。

## 相关提交
- `b196334`

## 关联 Issue
- 暂无明确 Issue ID，若需自动关联请补充 `Closes #<id>`。
