### PR TITLE
chore: prune dead adapter paths and refresh CI/runtime deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,15 +18,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: false
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -31,12 +31,12 @@ jobs:
           fi
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: false
 

--- a/README.md
+++ b/README.md
@@ -35,15 +35,12 @@ uv tool upgrade compass-a2a
 Run (complete example)
 
 ```bash
-export A2A_HOST=0.0.0.0
-export A2A_PORT=8000
-export A2A_PUBLIC_URL=https://your-domain.example.com/compass-a2a
-export A2A_COMPASS_API_BASE_URL=https://your-domain.example.com/api/v1
-
+A2A_HOST=0.0.0.0 \
+A2A_PORT=8000 \
+A2A_PUBLIC_URL=https://your-domain.example.com/compass-a2a \
+A2A_COMPASS_API_BASE_URL=https://your-domain.example.com/api/v1 \
 compass-a2a
 ```
-
-Use environment variable assignment only this way; this is required for a shell script or process manager to pass values into the `compass-a2a` process.
 
 `A2A_COMPASS_API_BASE_URL` is required and should point to the upstream Compass API service used for identity, skill dispatch, and token exchange.
 

--- a/README.md
+++ b/README.md
@@ -35,12 +35,15 @@ uv tool upgrade compass-a2a
 Run (complete example)
 
 ```bash
-A2A_HOST=0.0.0.0 \
-A2A_PORT=8000 \
-A2A_PUBLIC_URL=https://your-domain.example.com/compass-a2a \
-A2A_COMPASS_API_BASE_URL=https://your-domain.example.com/api/v1 \
+export A2A_HOST=0.0.0.0
+export A2A_PORT=8000
+export A2A_PUBLIC_URL=https://your-domain.example.com/compass-a2a
+export A2A_COMPASS_API_BASE_URL=https://your-domain.example.com/api/v1
+
 compass-a2a
 ```
+
+Use environment variable assignment only this way; this is required for a shell script or process manager to pass values into the `compass-a2a` process.
 
 `A2A_COMPASS_API_BASE_URL` is required and should point to the upstream Compass API service used for identity, skill dispatch, and token exchange.
 

--- a/src/compass_a2a/app.py
+++ b/src/compass_a2a/app.py
@@ -15,12 +15,9 @@ from .executor import CompassAdapterExecutor
 from .principal import CompassPrincipal
 
 
-class IdentityAwareCallContextBuilder(DefaultCallContextBuilder):
+class PrincipalAwareCallContextBuilder(DefaultCallContextBuilder):
     def build(self, request: Request):
         context = super().build(request)
-        identity = getattr(request.state, "user_identity", None)
-        if identity:
-            context.state["identity"] = identity
         principal = getattr(request.state, "compass_principal", None)
         if isinstance(principal, CompassPrincipal):
             context.state["compass_principal"] = principal
@@ -38,7 +35,7 @@ def build_app(
         agent_executor=CompassAdapterExecutor(settings, gateway),
         task_store=InMemoryTaskStore(),
     )
-    context_builder = IdentityAwareCallContextBuilder()
+    context_builder = PrincipalAwareCallContextBuilder()
 
     app = A2AFastAPI(title=settings.app_name, version=settings.adapter_version)
     app.get("/healthz")(lambda: {"status": "ok"})

--- a/src/compass_a2a/auth.py
+++ b/src/compass_a2a/auth.py
@@ -70,6 +70,5 @@ def add_basic_auth_middleware(app: FastAPI, authenticator: CompassAuthenticator)
         except CompassGatewayError:
             return _unauthorized_response()
 
-        request.state.user_identity = principal.identity
         request.state.compass_principal = principal
         return await call_next(request)

--- a/src/compass_a2a/cli.py
+++ b/src/compass_a2a/cli.py
@@ -5,8 +5,6 @@ from .config import Settings
 
 def main() -> int:
     settings = Settings()
-    if settings.public_url is None:
-        settings.public_url = f"http://{settings.host}:{settings.port}"
 
     uvicorn.run(
         "compass_a2a.app:build_app",

--- a/uv.lock
+++ b/uv.lock
@@ -1062,7 +1062,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1070,9 +1070,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 变更概览

### Runtime Adapter
- 删除 `cli.py` 中不会进入实际应用实例的 `public_url` 本地兜底赋值死代码。
- 删除认证中间件与调用上下文中未被任何执行路径消费的 `user_identity -> identity` 透传链路。
- 将上下文构建器重命名为 `PrincipalAwareCallContextBuilder`，使职责与当前实现一致。

### Runtime Dependency
- 更新 `uv.lock`，将运行时依赖树中的 `requests` 从 `2.32.5` 升级到 `2.33.0`。
- 该升级用于消除 CI 中 `pip-audit` 命中的 `CVE-2026-25645`。

### CI Workflows
- 升级 `.github/workflows/ci.yml` 与 `.github/workflows/publish.yml` 中的 GitHub Actions 版本：
  - `actions/checkout@v4` -> `@v5`
  - `actions/setup-python@v5` -> `@v6`
  - `astral-sh/setup-uv@v4` -> `@v7`
- 目标是消除 GitHub Actions 的 Node 20 deprecation annotation，并与 Node 24 运行时兼容。

### README
- 本分支中途曾调整启动示例，但后续已按评审意见回退。
- 当前 PR 相对 `master` **没有净 README 改动**。

## 相关提交
- `docs: clarify A2A env startup example`
- `refactor: remove dead identity and public-url setup`
- `docs: restore inline env startup example`
- `build: upgrade requests to 2.33.0`
- `ci: upgrade GitHub Actions runtime versions`

## 验证
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest`
- `uv export --format requirements.txt --no-dev --locked --no-emit-project --output-file /tmp/runtime-requirements.txt`
- `uv run pip-audit --requirement /tmp/runtime-requirements.txt`
- `uv build --no-sources`
- `bash ./scripts/smoke_test_built_cli.sh dist/compass_a2a-0.1.2.dev3+ga58240d78.d20260326-py3-none-any.whl`
- `bash ./scripts/smoke_test_built_cli.sh dist/compass_a2a-0.1.2.dev3+ga58240d78.d20260326.tar.gz`
- GitHub CI run `23578684691` 已通过

## Issue 关联
- 本 PR 无直接对应 issue。
- 当前不使用 `closes` / `fixes` / `related`，避免误关联。
